### PR TITLE
Refactor DNS Provider Structure + Rename Methods for Clarity + Add Docker Support

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,12 +14,12 @@ import (
 func main() {
 	config.LoadConfig()
 
-	var svc dns.DNSImpl
+	var dnsService dns.DNSImpl
 	// TODO: Handle multiple DNS providers better than this
 	if config.Conf.DOToken != "" {
-		svc = digitalocean.NewService(config.Conf.DOToken)
+		dnsService = digitalocean.NewService(config.Conf.DOToken)
 	} else if config.Conf.GCP != (config.GCP{}) {
-		svc = gcp.NewService()
+		dnsService = gcp.NewService()
 	} else {
 		log.Fatal("No valid DNS provider found")
 	}
@@ -32,7 +32,7 @@ func main() {
 				log.Fatalf("Invalid DNS request: %+v", dnsReq)
 			}
 
-			svc.SetRecord(dnsReq)
+			dnsService.UpdateRecord(dnsReq)
 		}
 	}
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,8 +6,8 @@ import (
 	domain "github.com/orkarstoft/dns-updater"
 	"github.com/orkarstoft/dns-updater/config"
 	"github.com/orkarstoft/dns-updater/dns"
-	"github.com/orkarstoft/dns-updater/dns/digitalocean"
-	"github.com/orkarstoft/dns-updater/dns/gcp"
+	"github.com/orkarstoft/dns-updater/dns/providers/digitalocean"
+	"github.com/orkarstoft/dns-updater/dns/providers/gcp"
 	"github.com/orkarstoft/dns-updater/ip"
 )
 

--- a/config/config.go
+++ b/config/config.go
@@ -29,7 +29,6 @@ func LoadConfig() {
 	viper.SetConfigName("config")
 	viper.SetConfigType("yaml")
 	viper.AddConfigPath(".")
-	viper.AddConfigPath("/run/secrets/")
 
 	err := viper.ReadInConfig()
 	if err != nil {

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -3,5 +3,5 @@ package dns
 import domain "github.com/orkarstoft/dns-updater"
 
 type DNSImpl interface {
-	SetRecord(*domain.DNSRequest)
+	UpdateRecord(*domain.DNSRequest)
 }

--- a/dns/providers/digitalocean/digitalocean.go
+++ b/dns/providers/digitalocean/digitalocean.go
@@ -26,7 +26,7 @@ func NewService(apiToken string) dns.DNSImpl {
 	return &Service{ctx: ctx, client: client}
 }
 
-func (s *Service) SetRecord(req *domain.DNSRequest) {
+func (s *Service) UpdateRecord(req *domain.DNSRequest) {
 	records, _, err := s.client.Domains.Records(s.ctx, req.GetDomain(), &godo.ListOptions{WithProjects: true})
 	if err != nil {
 		log.Fatal(err)

--- a/dns/providers/gcp/gcp.go
+++ b/dns/providers/gcp/gcp.go
@@ -26,7 +26,7 @@ func NewService() dns.DNSImpl {
 	return &Service{ctx: ctx, client: client}
 }
 
-func (s *Service) SetRecord(req *domain.DNSRequest) {
+func (s *Service) UpdateRecord(req *domain.DNSRequest) {
 	fullRecordName := fmt.Sprintf("%s.%s.", req.GetRecordName(), req.GetDomain())
 
 	// List existing records in the zone

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,19 @@
+services:
+  dns-updater:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      platforms:
+        - linux/amd64
+        - linux/arm64
+    configs:
+      - config
+    secrets:
+      - gcp_service_account
+
+secrets:
+  gcp_service_account:
+    file: serviceaccount.json
+configs:
+  config:
+    file: config.yaml


### PR DESCRIPTION
This pull request includes several significant changes to the DNS updater project, including refactoring the DNS provider structure, renaming methods for clarity, and adding Docker support. Below are the most important changes:

### Refactoring DNS provider structure:

* [`cmd/main.go`](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L9-R22): Updated import paths for DNS providers to use the new structure under `dns/providers/`.
* `dns/providers/digitalocean/digitalocean.go` and `dns/providers/gcp/gcp.go`: Moved files from `dns/` to `dns/providers/`. [[1]](diffhunk://#diff-cef26026cced9abdb9aa21ea697c35a04468f18cd53dfbe308d678788e7d2f8aL29-R29) [[2]](diffhunk://#diff-3a928dc30c5e97ab2f9de866927d1f2815d523acd62fd83710f224cbe22e4a0fL29-R29)

### Method renaming for clarity:

* [`dns/dns.go`](diffhunk://#diff-141a2edcbe282970635d9a6a5d99370be8dd9647b2636e2f03799592bde6f253L6-R6): Renamed the method `SetRecord` to `UpdateRecord` in the `DNSImpl` interface.
* [`cmd/main.go`](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L35-R35): Updated method calls from `SetRecord` to `UpdateRecord` to reflect the new method name.

### Docker support:

* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R1-R19): Added a new Docker Compose configuration to build and run the `dns-updater` service with support for multiple platforms and secrets management.

### Configuration changes:

* [`config/config.go`](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L32): Removed the additional configuration path `/run/secrets/` from the `LoadConfig` function.