### PR TITLE
Adding issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug Report
+about: Create a report to help improve dns-updater
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+**Describe the Bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Configuration used
+2. Action performed
+3. Error received
+
+**Expected Behavior**
+A clear and concise description of what you expected to happen.
+
+**Logs**
+If applicable, add logs or error messages.
+
+**Environment:**
+ - OS: [e.g. Ubuntu 22.04]
+ - DNS Provider: [e.g. DigitalOcean]
+ - Version: [e.g. 1.0.0]
+
+**Additional Context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -1,0 +1,24 @@
+---
+name: Documentation Request
+about: Suggest improvements or additions to documentation
+title: '[DOCS] '
+labels: documentation
+assignees: ''
+---
+
+**Documentation Area**
+Specify which part of the documentation needs improvement:
+- [ ] README
+- [ ] Configuration Examples
+- [ ] Installation Instructions
+- [ ] Usage Guidelines
+- [ ] Other
+
+**Describe the Issue**
+What is unclear or missing in the current documentation?
+
+**Suggested Improvement**
+Describe what information should be added or clarified.
+
+**Additional Context**
+Add any other context or examples that would help improve the documentation.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature Request
+about: Suggest an idea for dns-updater
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.
+
+**Implementation ideas (optional)**
+If you have any technical suggestions for implementation, please share them here.


### PR DESCRIPTION
This pull request includes the addition of three new issue templates to improve the process of reporting bugs, requesting documentation changes, and suggesting new features. 

New issue templates:

* [`.github/ISSUE_TEMPLATE/bug_report.md`](diffhunk://#diff-185833cb26d7ac66a4d39042fd576a820c2c2c6d05ad18973bb9c7dce77267c5R1-R30): Added a template for reporting bugs, including sections for describing the bug, steps to reproduce, expected behavior, logs, environment details, and additional context.
* [`.github/ISSUE_TEMPLATE/documentation_request.md`](diffhunk://#diff-99797f0f22c66f01f502109ba3e4e0f77afda5af7e8c72ab744f603845273b82R1-R24): Added a template for requesting documentation improvements, with sections for specifying the documentation area, describing the issue, suggesting improvements, and providing additional context.
* [`.github/ISSUE_TEMPLATE/feature_request.md`](diffhunk://#diff-148870715557a13127284f8aeaa28002ed6b034268af13c5d030ab59fd078220R1-R22): Added a template for suggesting new features, including sections for describing the problem, proposed solution, alternatives considered, additional context, and optional implementation ideas.