### PR TITLE
Improved config package

### DIFF
--- a/application/service.go
+++ b/application/service.go
@@ -40,7 +40,7 @@ func New(opts Options) *Service {
 		log.Fatal("No valid DNS provider specified")
 	}
 
-	if config.Conf.Tracing.Enabled && opts.Tracer == nil {
+	if config.Conf.Tracing.GetBool("enabled") && opts.Tracer == nil {
 		log.Fatal("No valid tracer specified")
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,7 +27,7 @@ func main() {
 		ProviderClient: dnsProvider,
 	}
 
-	if config.Conf.Tracing.Enabled {
+	if config.Conf.Tracing.GetBool("enabled") {
 		tracingService, shutdownTracer := tracing.NewService(ctx, dnsProvider)
 		defer shutdownTracer(ctx)
 
@@ -46,11 +46,11 @@ func main() {
 
 func getDNSProvider() dns.DNSImpl {
 	var dnsProvider dns.DNSImpl
-	switch config.Conf.Provider.Name {
+	switch config.Conf.Provider.GetString("name") {
 	case "googlecloudplatform":
 		dnsProvider = gcp.NewService()
 	case "digitalocean":
-		dnsProvider = digitalocean.NewService(config.Conf.GetProviderString("token"))
+		dnsProvider = digitalocean.NewService(config.Conf.Provider.GetString("token"))
 	default:
 		log.Fatal("No vaild DNS provider specified")
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -41,12 +41,15 @@ func LoadConfig() {
 	viper.SetConfigType("yaml")
 	viper.AddConfigPath(".")
 
-	err := viper.ReadInConfig()
-	if err != nil {
-		log.Fatal("Can't read config file:", err)
+	if err := viper.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			log.Fatal("Config file not found: %w", err)
+		} else {
+			log.Fatal("Config file found but error occured: %w", err)
+		}
 	}
 
-	err = viper.Unmarshal(&conf)
+	err := viper.Unmarshal(&conf)
 	if err != nil {
 		log.Fatal("Can't unmarshal config file:", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -9,14 +9,14 @@ import (
 )
 
 type Config struct {
-	Provider Provider `mapstructure:"provider"`
-	Updates  []Update `mapstructure:"updates"`
-	Tracing  Tracing  `mapstructure:"tracing"`
+	Provider Provider
+	Updates  []Update
+	Tracing  Tracing
 }
 
 type Provider struct {
-	Name   string                 `mapstructure:"name"`
-	Config map[string]interface{} `mapstructure:"config"`
+	Name   string
+	Config map[string]interface{}
 }
 
 type Update struct {
@@ -27,10 +27,10 @@ type Update struct {
 }
 
 type Tracing struct {
-	Enabled       bool   `mapstructure:"enabled"`
-	Host          string `mapstructure:"host"`
-	Port          int    `mapstructure:"port"`
-	AllowInsecure bool   `mapstructure:"AllowInsecure"`
+	Enabled       bool
+	Host          string
+	Port          int
+	AllowInsecure bool
 }
 
 var Conf Config

--- a/config/config.go
+++ b/config/config.go
@@ -55,8 +55,6 @@ func LoadConfig() {
 	}
 
 	Conf = conf
-
-	log.Printf("Config loaded: %+v", conf)
 }
 
 func (c Config) GetProviderString(s string) string {

--- a/config/config.go
+++ b/config/config.go
@@ -15,8 +15,8 @@ type Config struct {
 }
 
 type Provider struct {
-	Name   string
-	Config map[string]interface{}
+	name   string
+	config map[string]interface{}
 }
 
 type Update struct {
@@ -27,10 +27,10 @@ type Update struct {
 }
 
 type Tracing struct {
-	Enabled       bool
-	Host          string
-	Port          int
-	AllowInsecure bool
+	enabled       bool
+	host          string
+	port          int
+	allowInsecure bool
 }
 
 var Conf Config
@@ -57,10 +57,29 @@ func LoadConfig() {
 	Conf = conf
 }
 
-func (c Config) GetProviderString(s string) string {
+func (p Provider) GetString(s string) string {
+	if s == "name" {
+		return viper.GetString("provider.name")
+	}
 	return viper.GetString(fmt.Sprintf("provider.config.%s", s))
 }
 
-func (c Config) GetProviderInt(i int) int {
+func (p Provider) GetInt(i int) int {
 	return viper.GetInt(fmt.Sprintf("provider.config.%s", strconv.Itoa(i)))
+}
+
+func (p Provider) GetBool(s string) bool {
+	return viper.GetBool(fmt.Sprintf("provider.config.%s", s))
+}
+
+func (t Tracing) GetString(s string) string {
+	return viper.GetString(fmt.Sprintf("tracing.%s", s))
+}
+
+func (t Tracing) GetInt(s string) int {
+	return viper.GetInt(fmt.Sprintf("tracing.%s", s))
+}
+
+func (t Tracing) GetBool(s string) bool {
+	return viper.GetBool(fmt.Sprintf("tracing.%s", s))
 }

--- a/dns/providers/gcp/gcp.go
+++ b/dns/providers/gcp/gcp.go
@@ -18,7 +18,7 @@ type Service struct {
 
 func NewService() dns.DNSImpl {
 	ctx := context.TODO()
-	client, err := googledns.NewService(ctx, option.WithCredentialsFile(config.Conf.GetProviderString("CredentialsFilePath")))
+	client, err := googledns.NewService(ctx, option.WithCredentialsFile(config.Conf.Provider.GetString("CredentialsFilePath")))
 	if err != nil {
 		log.Fatalf("Failed to create DNS client: %v", err)
 	}
@@ -28,7 +28,7 @@ func NewService() dns.DNSImpl {
 }
 
 func (s *Service) UpdateRecord(ctx context.Context, req *domain.DNSRequest) error {
-	projectID := config.Conf.GetProviderString("ProjectId")
+	projectID := config.Conf.Provider.GetString("ProjectId")
 	fullRecordName := fmt.Sprintf("%s.%s.", req.GetRecordName(), req.GetDomain())
 
 	records, err := s.listRecords(projectID, req.GetZone())

--- a/dns/tracing/otel.go
+++ b/dns/tracing/otel.go
@@ -28,11 +28,11 @@ var serviceName = semconv.ServiceNameKey.String("dns-updater")
 // providers.
 func initConn() (*grpc.ClientConn, error) {
 	// It connects the OpenTelemetry Collector through local gRPC connection.
-	tracingTarget := fmt.Sprintf("%s:%d", config.Conf.Tracing.Host, config.Conf.Tracing.Port)
+	tracingTarget := fmt.Sprintf("%s:%d", config.Conf.Tracing.GetString("host"), config.Conf.Tracing.GetInt("port"))
 
 	var conn *grpc.ClientConn
 	var err error
-	if config.Conf.Tracing.AllowInsecure {
+	if config.Conf.Tracing.GetBool("allowInsecure") {
 		conn, err = grpc.NewClient(tracingTarget,
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		)


### PR DESCRIPTION
This pull request includes several changes to improve the configuration handling in the application by replacing direct struct field access with methods that use the `viper` library for retrieving configuration values. Additionally, the `mapstructure` tags have been removed from the `Config` struct and its nested structs.

Improvements to configuration handling:

* [`application/service.go`](diffhunk://#diff-707c8bdbf75829be336a4bb210f731dabd26449122f43eb6e2e04c69babeb528L43-R43): Updated the condition to check if tracing is enabled using the `GetBool` method instead of direct field access.
* [`cmd/main.go`](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L30-R30): Replaced direct field access with `GetBool` and `GetString` methods for checking if tracing is enabled and retrieving the DNS provider name and token. [[1]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L30-R30) [[2]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L49-R53)
* [`config/config.go`](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L12-R19): Removed `mapstructure` tags from the `Config`, `Provider`, and `Tracing` structs, and added methods to retrieve configuration values using `viper`. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L12-R19) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L30-R33) [[3]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L44-R85)
* [`dns/providers/gcp/gcp.go`](diffhunk://#diff-3a928dc30c5e97ab2f9de866927d1f2815d523acd62fd83710f224cbe22e4a0fL21-R21): Updated the `NewService` and `UpdateRecord` functions to use the `GetString` method for retrieving configuration values. [[1]](diffhunk://#diff-3a928dc30c5e97ab2f9de866927d1f2815d523acd62fd83710f224cbe22e4a0fL21-R21) [[2]](diffhunk://#diff-3a928dc30c5e97ab2f9de866927d1f2815d523acd62fd83710f224cbe22e4a0fL31-R31)
* [`dns/tracing/otel.go`](diffhunk://#diff-9b84b03e5ab711f48c2153740c5a97ca6b2aa4d841a498c86ef3460efc1cb167L31-R35): Modified the `initConn` function to use the `GetString`, `GetInt`, and `GetBool` methods for retrieving tracing configuration values.