### PR TITLE
Fix: DigitalOcean provider fails to update DNS records on WAN IP change

### DIFF
--- a/dns/providers/digitalocean/digitalocean.go
+++ b/dns/providers/digitalocean/digitalocean.go
@@ -64,10 +64,8 @@ func (s *Service) getRecords(ctx context.Context, req *domain.DNSRequest) ([]god
 
 func findMatchingRecord(records []godo.DomainRecord, req *domain.DNSRequest) *godo.DomainRecord {
 	for _, record := range records {
-		if record.Name == req.GetRecordName() {
-			if record.Data == req.GetIP() {
-				return &record
-			}
+		if record.Name == req.GetRecordName() && record.Type == req.GetRecordType() {
+			return &record
 		}
 	}
 	return nil


### PR DESCRIPTION
This pull request includes a change to the `dns/providers/digitalocean/digitalocean.go` file to improve the accuracy of DNS record matching.

Improvements to DNS record matching:

* [`dns/providers/digitalocean/digitalocean.go`](diffhunk://#diff-cef26026cced9abdb9aa21ea697c35a04468f18cd53dfbe308d678788e7d2f8aL67-L72): Modified the `findMatchingRecord` function in the DigitalOcena provider to include a check for the record type in addition to the record name when finding a matching record. This ensures that the correct type of DNS record is matched.

Also, I removed the check to compare the record's value with the new value, which created bug #16.
This fixes #16 