### PR TITLE
Feat: Ability to set root domain a record

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,7 +48,7 @@ func getDNSProvider() dns.DNSImpl {
 	var dnsProvider dns.DNSImpl
 	switch config.Conf.Provider.GetString("name") {
 	case "googlecloudplatform":
-		dnsProvider = gcp.NewService()
+		dnsProvider = gcp.NewService(config.Conf.Provider.GetString("projectId"), config.Conf.Provider.GetString("credentialsFile"))
 	case "digitalocean":
 		dnsProvider = digitalocean.NewService(config.Conf.Provider.GetString("token"))
 	default:

--- a/dns/providers/gcp/gcp.go
+++ b/dns/providers/gcp/gcp.go
@@ -6,29 +6,29 @@ import (
 	"log"
 
 	domain "github.com/orkarstoft/dns-updater"
-	"github.com/orkarstoft/dns-updater/config"
 	"github.com/orkarstoft/dns-updater/dns"
 	googledns "google.golang.org/api/dns/v1"
 	"google.golang.org/api/option"
 )
 
 type Service struct {
-	client *googledns.Service
+	client    *googledns.Service
+	projectId string
 }
 
-func NewService() dns.DNSImpl {
+func NewService(projectId, credentialsFile string) dns.DNSImpl {
 	ctx := context.TODO()
-	client, err := googledns.NewService(ctx, option.WithCredentialsFile(config.Conf.Provider.GetString("CredentialsFilePath")))
+	client, err := googledns.NewService(ctx, option.WithCredentialsFile(credentialsFile))
 	if err != nil {
 		log.Fatalf("Failed to create DNS client: %v", err)
 	}
 	return &Service{
-		client: client,
+		client:    client,
+		projectId: projectId,
 	}
 }
 
 func (s *Service) UpdateRecord(ctx context.Context, req *domain.DNSRequest) error {
-	projectID := config.Conf.Provider.GetString("ProjectId")
 	fullRecordName := fmt.Sprintf("%s.%s.", req.GetRecordName(), req.GetDomain())
 
 	records, err := s.listRecords(projectID, req.GetZone())

--- a/dns/providers/gcp/gcp.go
+++ b/dns/providers/gcp/gcp.go
@@ -96,7 +96,7 @@ func (s *Service) updateDNSRecord(projectID, zone string, oldRecord *googledns.R
 	_, err := s.client.Changes.Create(projectID, zone, change).Do()
 	if err != nil {
 		return &dns.DNSProviderError{
-			Provider:  "DigitalOcean",
+			Provider:  "GoogleCloudPlatform",
 			Operation: "record update",
 			Err:       err,
 		}


### PR DESCRIPTION
## TL;DR
- Decoupled GCP provider package and config package
- Fixed typo in the GCP provider error handling (was set to digitalocean. Copy'n'paste error)
- GCP provider now handles "@" as root record (e.g. `example.com.`)
- This fixes #8 

This pull request includes several changes to improve the DNS provider configuration and functionality for Google Cloud Platform (GCP). The most important changes include modifying the `NewService` function to accept `projectId` and `credentialsFile` as parameters, updating the `UpdateRecord` method to utilize the `projectId` from the service struct, and correcting the provider name in error messages.

Improvements to GCP DNS provider configuration:

* [`cmd/main.go`](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L51-R51): Updated the `getDNSProvider` function to pass `projectId` and `credentialsFile` when creating a new GCP service.

* [`dns/providers/gcp/gcp.go`](diffhunk://#diff-3a928dc30c5e97ab2f9de866927d1f2815d523acd62fd83710f224cbe22e4a0fL9-R39): Modified the `NewService` function to accept `projectId` and `credentialsFile` as parameters, and added `projectId` to the service struct.

Enhancements to DNS record updates:

* [`dns/providers/gcp/gcp.go`](diffhunk://#diff-3a928dc30c5e97ab2f9de866927d1f2815d523acd62fd83710f224cbe22e4a0fL49-R54): Updated the `UpdateRecord` method to use `projectId` from the service struct instead of fetching it from the configuration. Also, added logic to handle root domain records.

* [`dns/providers/gcp/gcp.go`](diffhunk://#diff-3a928dc30c5e97ab2f9de866927d1f2815d523acd62fd83710f224cbe22e4a0fL78-R85): Modified the `updateDNSRecord` function to accept `fullRecordName` as a parameter and use it for the new record name.

Error message correction:

* [`dns/providers/gcp/gcp.go`](diffhunk://#diff-3a928dc30c5e97ab2f9de866927d1f2815d523acd62fd83710f224cbe22e4a0fL94-R99): Corrected the provider name in error messages from "DigitalOcean" to "GoogleCloudPlatform".